### PR TITLE
Enable logging in production

### DIFF
--- a/darksite/darksite/settings.py
+++ b/darksite/darksite/settings.py
@@ -38,22 +38,28 @@ ALLOWED_HOSTS = [
 
 # Application definition
 
-INSTALLED_APPS = [
+DJANGO_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+]
 
+THIRD_PARTY_APPS = [
     'adminsortable2',
     'corsheaders',
     'graphene_django',
+]
 
+CUSTOM_APPS = [
     'account',
     'cms',
     'cms.blog',
 ]
+
+INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + CUSTOM_APPS
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
@@ -207,3 +213,52 @@ CORS_ORIGIN_ALLOW_ALL = True
 GRAPHENE = {
     'SCHEMA': 'darksite.schema.schema',
 }
+
+
+# Logging Configuration
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'standard': {
+            'datefmt': '%Y-%m-%d %H:%M:%S',
+            'format': '[%(asctime)s] %(levelname)8s [%(name)s:%(lineno)s] %(message)s',  # noqa
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'standard',
+        },
+        'null': {
+            'class': 'logging.NullHandler',
+            'level': 'DEBUG',
+        },
+    },
+    'loggers': {
+        # Root Handler
+        '': {
+            'handlers': ['console'],
+            'level': 'WARNING',
+        },
+
+        # Customized Handlers
+        'django.request': {
+            'level': 'ERROR',
+            'propagate': True,
+        },
+        'django.security.DisallowedHost': {
+            'handlers': ['null'],
+            'propagate': False,
+        },
+    }
+}
+
+# We want more logging for our custom apps
+for app in CUSTOM_APPS:
+    LOGGING['loggers'][app] = {
+        'handlers': ['console'],
+        'level': 'INFO',
+        'propagate': False,
+    }

--- a/deploy/ansible/roles/gunicorn/defaults/main.yml
+++ b/deploy/ansible/roles/gunicorn/defaults/main.yml
@@ -5,3 +5,7 @@ gunicorn_socket_uri: "unix:{{ gunicorn_socket }}"
 gunicorn_service_conf: /etc/systemd/system/gunicorn.service
 gunicorn_socket_conf: /etc/systemd/system/gunicorn.socket
 gunicorn_tempfile_conf: /etc/tmpfiles.d/gunicorn.conf
+
+gunicorn_syslog_conf: /etc/rsyslog.d/darksite.conf
+gunicorn_syslog_file: /var/log/darksite/gunicorn.log
+gunicorn_syslog_identifier: darksite-gunicorn

--- a/deploy/ansible/roles/gunicorn/handlers/main.yml
+++ b/deploy/ansible/roles/gunicorn/handlers/main.yml
@@ -20,3 +20,9 @@
     name: gunicorn.socket
     state: restarted
   listen: reload gunicorn
+
+- name: restart syslog
+  become: true
+  service:
+    name: rsyslog
+    state: restarted

--- a/deploy/ansible/roles/gunicorn/tasks/main.yml
+++ b/deploy/ansible/roles/gunicorn/tasks/main.yml
@@ -4,8 +4,25 @@
     name: gunicorn
     virtualenv: "{{ gunicorn_venv }}"
 
+- name: Create log file directory
+  become: true
+  file:
+    mode: 0777
+    owner: root
+    path: "{{ gunicorn_syslog_file | dirname }}"
+    state: directory
+
+- name: Upload syslog configuration for gunicorn
+  become: true
+  template:
+    src: syslog.conf.j2
+    dest: "{{ gunicorn_syslog_conf }}"
+    owner: root
+    mode: 0644
+  notify: restart syslog
+
 - name: Upload gunicorn service configuration
-  become: yes
+  become: true
   template:
     src: gunicorn.service.j2
     dest: "{{ gunicorn_service_conf }}"
@@ -16,7 +33,7 @@
   - reload gunicorn
 
 - name: Upload gunicorn socket configuration
-  become: yes
+  become: true
   template:
     src: gunicorn.socket.j2
     dest: "{{ gunicorn_socket_conf }}"
@@ -27,7 +44,7 @@
   - reload gunicorn
 
 - name: Upload gunicorn tempfile configuration
-  become: yes
+  become: true
   template:
     src: tempfiles.conf.j2
     dest: "{{ gunicorn_tempfile_conf }}"
@@ -37,7 +54,7 @@
   - reload gunicorn
 
 - name: Start and enable gunicorn
-  become: yes
+  become: true
   service:
     name: gunicorn.socket
     enabled: yes

--- a/deploy/ansible/roles/gunicorn/templates/gunicorn.service.j2
+++ b/deploy/ansible/roles/gunicorn/templates/gunicorn.service.j2
@@ -15,6 +15,9 @@ ExecStart={{ gunicorn_venv }}/bin/gunicorn --pid /run/gunicorn/pid   \
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier={{ gunicorn_syslog_identifier }}
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/ansible/roles/gunicorn/templates/syslog.conf.j2
+++ b/deploy/ansible/roles/gunicorn/templates/syslog.conf.j2
@@ -1,0 +1,2 @@
+if $programname == '{{ gunicorn_syslog_identifier }}' then {{ gunicorn_syslog_file }}
+  & stop


### PR DESCRIPTION
The application now outputs logs to stdout. In production, those logs are collected by syslog and stored in a logfile.